### PR TITLE
Change inCEPEnvironment check to account for versions of CC pre 2018

### DIFF
--- a/src/cs-interface.ts
+++ b/src/cs-interface.ts
@@ -199,7 +199,7 @@ export interface GradientStop {
 
 /**
  * Stores gradient color information.
- * 
+ *
  * @param type          The gradient type, must be "linear".
  * @param direction     A Direction object for the direction of the gradient
  (up, down, right, or left).
@@ -342,7 +342,7 @@ export const THEME_COLOR_CHANGED_EVENT: string =
 /** Returns true if a cep environment is detected.
  */
 export function inCEPEnvironment(): boolean {
-  return !!window.cep && !!window.cep_node && !!window.__adobe_cep__
+  return !!window.cep || !!window.cep_node || !!window.__adobe_cep__
 }
 
 /** Retrieves information about the host environment in which the
@@ -896,7 +896,7 @@ export function setContextMenu(menu: string, callback: Function) {
  * - an item without menu ID or menu name is disabled and is not shown.
  * - if the item label is "---" (three hyphens) then it is treated as a separator. The menu ID in this case will always be NULL.
  * - Checkable attribute takes precedence over Checked attribute.
- * - a PNG icon. For optimal display results please supply a 16 x 16px icon as larger dimensions will increase the size of the menu item. 
+ * - a PNG icon. For optimal display results please supply a 16 x 16px icon as larger dimensions will increase the size of the menu item.
      The Chrome extension contextMenus API was taken as a reference.
  * - the items with icons and checkable items cannot coexist on the same menu level. The former take precedences over the latter.
      https://developer.chrome.com/extensions/contextMenus
@@ -906,7 +906,7 @@ export function setContextMenu(menu: string, callback: Function) {
  *
  * @description An example menu JSON:
  *
- * { 
+ * {
  *      "menu": [
  *          {
  *              "id": "menuItemId1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,13 +20,15 @@ function evalScript(script: string, callback: (executionResult: any) => void) {
   if (callback === null || callback === undefined) {
     callback = function callback(result) {};
   }
-  script = `
-  try {
-    ${script}
-  } catch(e) {
-    '{"error": "' + e.name + '", "message": "' + e.message.replace(/"/g, \"'\") + '", "stack": "' + (e.stack ? e.stack.replace(/"/g, \"'\") : \"\") + '"}'
-  }
-  `;
+  script = `try {
+  ${script}
+} catch(e) {
+  app.objectToJSON({
+    error: e.name,
+    message: e.message,
+    stack: (e.stack ? e.stack : '')
+  });
+}`;
   window.__adobe_cep__.evalScript(script, callback);
 }
 
@@ -41,7 +43,8 @@ export function loadExtendscript(fileName: string): Promise<any> {
   var extensionRoot = cs.getSystemPath(cs.SystemPath.EXTENSION);
   // @ts-ignore
   return new Promise(function(resolve, reject) {
-    const filePath = path.join(extensionRoot, fileName);
+    const filePath = path.join(extensionRoot, fileName).replace("\\", "/");
+
     evalScript(`$.evalFile("${filePath}")`, function(result) {
       if (!result || result === "undefined") return resolve();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,10 @@ export function loadExtendscript(fileName: string): Promise<any> {
   var extensionRoot = cs.getSystemPath(cs.SystemPath.EXTENSION);
   // @ts-ignore
   return new Promise(function(resolve, reject) {
-    const filePath = path.join(extensionRoot, fileName).split("\\").join("/");
+    const filePath = path
+      .join(extensionRoot, fileName)
+      .split("\\")
+      .join("/");
 
     evalScript(`$.evalFile("${filePath}")`, function(result) {
       if (!result || result === "undefined") return resolve();
@@ -51,9 +54,7 @@ export function loadExtendscript(fileName: string): Promise<any> {
       if (result.error != undefined) {
         reject(
           new Error(
-            `ExtendScript ${result.error}: ${
-              result.message
-            }\n${result.stack}`
+            `ExtendScript ${result.error}: ${result.message}\n${result.stack}`
           )
         );
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function loadExtendscript(fileName: string): Promise<any> {
   var extensionRoot = cs.getSystemPath(cs.SystemPath.EXTENSION);
   // @ts-ignore
   return new Promise(function(resolve, reject) {
-    const filePath = path.join(extensionRoot, fileName).replace("\\", "/");
+    const filePath = path.join(extensionRoot, fileName).split("\\").join("/");
 
     evalScript(`$.evalFile("${filePath}")`, function(result) {
       if (!result || result === "undefined") return resolve();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,16 @@ export function loadExtendscript(fileName: string): Promise<any> {
         result = JSON.parse(result);
       } catch (err) {}
 
+      if (result.error != undefined) {
+        reject(
+          new Error(
+            `ExtendScript ${result.error}: ${
+              result.message
+            }\n${result.stack}`
+          )
+        );
+      }
+
       resolve(result);
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,14 +21,10 @@ function evalScript(script: string, callback: (executionResult: any) => void) {
     callback = function callback(result) {};
   }
   script = `try {
-  ${script}
-} catch(e) {
-  app.objectToJSON({
-    error: e.name,
-    message: e.message,
-    stack: (e.stack ? e.stack : '')
-  });
-}`;
+    ${script}
+  } catch(e) {
+    '{"error": "' + e.name + '", "message": "' + e.message.replace(/"/g, \"'\") + '", "stack": "' + (e.stack ? e.stack.replace(/"/g, \"'\") : \"\") + '"}'
+  }`;
   window.__adobe_cep__.evalScript(script, callback);
 }
 


### PR DESCRIPTION
window.cep_node only exists as of CC2018, causing `inCEPEnvironment()` to return `false` overzealously.

Really, though, if _any_ of these properties exist we know we're in a CEP panel; this way is more inclusive.