### PR TITLE
Replace .npmrc with registry config in action, fixing fresh install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        version: '10.x'
+        node-version: '10.x'
+        registry-url: 'https://registry.npmjs.org'
     - run: npm install -g yarn
     - run: yarn install
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - run: npm publish
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Hi, thanks for the awesome work on this!

Right now, when you clone the repository locally, and run `npm install` (or `yarn`), you’ll receive and error that you’re missing the `NPM_TOKEN` environment variable in the `.npmrc` file.

That environment variable is only for running `npm publish` via GitHub Actions, correct?

I’ve update the GitHub Actions config to use `actions/checkout@v2`, fixed the `setup-node` version config, and added the [more recent config option](https://github.com/actions/setup-node#usage) to change the registry URL without needing the `.npmrc` file.

My fork is only failing on the `npm publish` step now (as it should without the `NPM_TOKEN`). So I think everything else you already had set up should be working, while fixing the initial install locally.